### PR TITLE
Refactor blog pages

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -4,6 +4,7 @@ import DarkModeToggle from "./DarkModeToggle"
 import SiteNav from "./SiteNav"
 
 import { rhythm, scale } from "../utils/typography"
+import AdobeFont from "@/components/AdobeFont"
 
 const Layout = ({
                   location,
@@ -75,6 +76,7 @@ const Layout = ({
         color: "var(--textNormal)",
       }}
     >
+      <AdobeFont />
       <SiteNav location={location} style={{ marginBottom: rhythm(1) }} />
       <header
         style={{

--- a/src/pages/friends.mdx
+++ b/src/pages/friends.mdx
@@ -1,6 +1,5 @@
 import Layout from "../components/layout"
 import GithubCorner from "../components/GithubCorner"
-import AdobeFont from "../components/AdobeFont"
 import { UtterancesComments } from "@/components/utterances"
 import Bio from "../components/Bio"
 import SEO from "../components/seo"
@@ -8,43 +7,42 @@ import { rhythm } from "@/utils/typography"
 import Helmet from "react-helmet"
 import "./friends.scss"
 
-<AdobeFont />
-<GithubCorner url="https://github.com/yujinyan/blog" />
+export default ({ children }) => <Layout location="friends">{children}</Layout>
+
+<GithubCorner url="https://github.com/yujinyan/blog/issues/46" />
 <Helmet htmlAttributes={{ lang: "en" }} />
 <SEO title="Friends 友链 | Yu Jinyan's Blog" />
-<Layout location="friends">
 
-  # Friends | <span lang="zh-cmn-Hans">友链</span>
+# Friends | <span lang="zh-cmn-Hans">友链</span>
 
-  Most authors nowadays publish their articles on platforms like WeChat, Juejin, or Medium.
-  Unfortunately, their content sometimes gets lost in a sea of clickbaity ads
-  that try to sell you programming tutorials by exploiting people's anxieties.
-  Even worse, many articles are locked inside a [walled garden](https://en.wikipedia.org/wiki/Closed_platform).
+Most authors nowadays publish their articles on platforms like WeChat, Juejin, or Medium.
+Unfortunately, their content sometimes gets lost in a sea of clickbaity ads
+that try to sell you programming tutorials by exploiting people's anxieties.
+Even worse, many articles are locked inside a [walled garden](https://en.wikipedia.org/wiki/Closed_platform).
 
-  Therefore, it's delightful to see there are still people out there,
-  tinkering with technologies of the Open Web and presenting their passion with a personal touch.
+Therefore, it's delightful to see there are still people out there,
+tinkering with technologies of the Open Web and presenting their passion with a personal touch.
 
-  This is a compilation of such personal blog sites that I have come across and found inspiring.
-  I hope this list can help you discover more sites like this one.
+This is a compilation of such personal blog sites that I have come across and found inspiring.
+I hope this list can help you discover more sites like this one.
 
-  ### [Stay Hungry Stay Foolish - Edward Elric's Blog](https://edward40.com/)
-  *Web Development, Rust, Programming Languages.*
-  I am a simple person. Whenever I see a site with that gorgeous Novela theme,
-  I try to add it to this list ;-).
+### [Stay Hungry Stay Foolish - Edward Elric's Blog](https://edward40.com/)
+*Web Development, Rust, Programming Languages.*
+I am a simple person. Whenever I see a site with that gorgeous Novela theme,
+I try to add it to this list ;-).
 
-  ### [Prin Blog](https://printempw.github.io)
-  *Fullstack Development.*
-  Prin says he's obsessed with layout and typography. I can testify to that.
+### [Prin Blog](https://printempw.github.io)
+*Fullstack Development.*
+Prin says he's obsessed with layout and typography. I can testify to that.
 
 
-  <hr style={{ marginBottom: rhythm(2.5) }} />
+<hr style={{ marginBottom: rhythm(2.5) }} />
 
   > Feel your site belongs to this list? Contact me or leave a comment below.
   > You can also edit [this page](https://github.com/yujinyan/blog/blob/master/src/pages/friends.mdx)
   > and send a PR directly.
 
-  <Bio />
+<Bio />
 
-  <UtterancesComments issueId={46} />
-</Layout>
+<UtterancesComments issueId={46} />
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,12 +1,11 @@
 import React from "react"
 import Helmet from "react-helmet"
-import { Link, graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 
 import Bio from "../components/Bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import GithubCorner from "../components/GithubCorner"
-import AdobeFont from "../components/AdobeFont"
 import { rhythm } from "../utils/typography"
 import { TranslateMark } from "../components/translate"
 import get from "lodash/get"
@@ -20,7 +19,6 @@ const BlogIndex = ({ data, location }) => {
     <Layout location={location} title={siteTitle}>
       <SEO title="All posts | Yu Jinyan's Blog" />
       <Helmet htmlAttributes={{ lang: "zh-cmn-Hans" }} />
-      <AdobeFont />
       <GithubCorner url="https://github.com/yujinyan/blog" />
       <Bio />
       {posts.map(({ node }) => {

--- a/src/pages/leetcode.jsx
+++ b/src/pages/leetcode.jsx
@@ -1,12 +1,11 @@
 import React from "react"
 import Helmet from "react-helmet"
-import { Link, graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 
 import Bio from "../components/Bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import GithubCorner from "../components/GithubCorner"
-import AdobeFont from "../components/AdobeFont"
 import { rhythm } from "../utils/typography"
 import { TranslateMark } from "../components/translate"
 import get from "lodash/get"
@@ -20,7 +19,6 @@ const BlogIndex = ({ data, location }) => {
     <Layout location={location} title={siteTitle}>
       <SEO title="LeetCode Notes | Yu Jinyan's Blog" />
       <Helmet htmlAttributes={{ lang: "zh-cmn-Hans" }} />
-      <AdobeFont />
       <GithubCorner url="https://github.com/yujinyan/blog" />
       <Bio />
       {posts.map(({ node }) => {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -4,7 +4,6 @@ import { Link, graphql } from "gatsby"
 import Bio from "../components/Bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import AdobeFont from "../components/AdobeFont"
 import { rhythm, scale } from "../utils/typography"
 import { TranslateInfo, TranslateMark } from "../components/translate"
 import ToC from "../components/ToC"
@@ -61,7 +60,6 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
       />
       {/* Currently, blog posts are either in English or Simplified Han */}
       <Helmet htmlAttributes={{ lang: post.frontmatter.english ? "en" : "zh-cmn-Hans" }} />
-      <AdobeFont />
       <article>
         <header>
           <h1


### PR DESCRIPTION
* By leveraging mdx's export layout feature, we can get rid of content nesting in mdx pages.
* Move `<AdobeFont />` to `<Layout />`